### PR TITLE
Clear track when destructing parent TrackNav.

### DIFF
--- a/src/io/TrackNav.hh
+++ b/src/io/TrackNav.hh
@@ -16,7 +16,8 @@ public:
       { Load(mc, verbose); };
   void Load(RAT::DS::MC *mc, bool verbose=false);
   void Clear();
-
+  ~TrackNav() { Clear(); };
+  
   TrackNode *Head() { return fHead; };
   TrackCursor Cursor(bool verbose=false) { return TrackCursor(fHead, verbose); };
 


### PR DESCRIPTION
TrackNav's implicitly defined destructor leaves an orphan track.
This causes a severe memory leak when iterating over many events.
Clear TrackNav in its destructor to destruct its child track.
